### PR TITLE
Add an option to launch script only if build succeeds

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/postbuildscript/PostBuildScript/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/postbuildscript/PostBuildScript/config.jelly
@@ -90,5 +90,9 @@
         </f:nested>
 
     </f:entry>
+    <f:entry field="scriptOnlyIfSuccess"
+             title="${%Execute script only if build succeeds}">
+        <f:checkbox />
+    </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
Add a checkbox 'scriptOnlyIfSuccess', so the scripts will be executed
only if the build succeeded. Also work for Matrix projects.
