### PR TITLE
added BUILD_RESULT to environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/postbuildscript/Processor.java
+++ b/src/main/java/org/jenkinsci/plugins/postbuildscript/Processor.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.postbuildscript;
 
 import com.google.common.base.Strings;
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
@@ -37,7 +38,7 @@ public class Processor {
         BuildListener listener,
         Configuration config) {
         this.build = build;
-        this.launcher = launcher;
+        this.launcher = launcher.decorateByEnv(new EnvVars("BUILD_RESULT", build.getResult().toString()));
         this.listener = listener;
         this.config = config;
         logger = new Logger(listener);


### PR DESCRIPTION
We have a need to run a post build script for any build status, however we need to perform certain actions if the build is success, failed or any other status. By adding the build result as a `BUILD_RESULT` environment variable, we can run a single script for all build results and use logic do determine what we action to perform.

```bash
if [[ "$BUILD_RESULT" == "SUCCESS" ]]; then
  ./success_script.sh
else
  ./failed_script.sh
fi
```