### PR TITLE
Declare matrix-project a mandatory dependency it actually is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.13</version>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/postbuildscript/MatrixPostBuildScript.java
+++ b/src/main/java/org/jenkinsci/plugins/postbuildscript/MatrixPostBuildScript.java
@@ -60,7 +60,7 @@ public class MatrixPostBuildScript extends PostBuildScript {
         return processor.process();
     }
 
-    @Extension(optional = true)
+    @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         @Nonnull


### PR DESCRIPTION
There are 2 extensions in the plugin and both depend on matrix plugin classes. One was marked as optional to handle this situation but I fail to see the point in hiding all extensions of the plugin in case matrix is not installed. Therefore, I declare the dependency to be mandatory.

Verified manually this actually fixes https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/PR-482/2/testReport/plugins/PostBuildScriptPluginTest/