### PR TITLE
Remove dead test code

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/postbuildscript/MatrixPostBuildScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/postbuildscript/MatrixPostBuildScriptTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.postbuildscript;
 
-import com.thoughtworks.xstream.XStream;
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.matrix.MatrixAggregator;
@@ -128,12 +127,6 @@ public class MatrixPostBuildScriptTest {
             true
         );
     }
-
-    private void givenScriptFromConfig(String configResourceName) {
-        XStream xstream = new XStream();
-        matrixPostBuildScript = (MatrixPostBuildScript) xstream.fromXML(getClass().getResource(configResourceName));
-    }
-
 
     private void givenDescriptor() {
         descriptor = new DescriptorImpl();


### PR DESCRIPTION
Nothing is calling this method, and even if someone wanted this functionality, a better way to achieve it is with the `@LocalData` test annotation:

https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/recipes/LocalData.html