### PR TITLE
Adjust for script security

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutor.java
@@ -5,6 +5,8 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.AbstractBuild;
+import hudson.model.Descriptor.FormException;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +22,7 @@ public class GroovyScriptExecutor {
     private final Logger log;
     private final SecureGroovyScript secureGroovyScript;
 
-    public GroovyScriptExecutor(Script script, List<String> arguments, AbstractBuild<?, ?> build, Logger log) {
+    public GroovyScriptExecutor(Script script, List<String> arguments, AbstractBuild<?, ?> build, Logger log) throws FormException {
         this.arguments = new ArrayList<>(arguments);
         this.build = build;
         this.log = log;

--- a/src/main/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutorFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutorFactory.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.postbuildscript.service;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Descriptor.FormException;
+
 import java.util.List;
 import org.jenkinsci.plugins.postbuildscript.logging.Logger;
 import org.jenkinsci.plugins.postbuildscript.model.Script;
@@ -16,7 +18,7 @@ public class GroovyScriptExecutorFactory {
         this.logger = logger;
     }
 
-    public GroovyScriptExecutor create(Script script, List<String> arguments) {
+    public GroovyScriptExecutor create(Script script, List<String> arguments) throws FormException {
         return new GroovyScriptExecutor(script, arguments, build, logger);
     }
 }


### PR DESCRIPTION
246c6351e5db updates the bom which updates script security plugin from 1366 to 1367 and it can now throw a FormException.

Before submitting a pull request, please make sure the following is done:

1. Fork [the repository](https://github.com/jenkinsci/postbuildscript-plugin) and create your branch from `master`.
2. If you've fixed a bug or added code that should be tested, please add JUnit tests.
3. Ensure the test suite passes (`mvn clean verify`).
4. Run `mvn hpi:run` and go to http://localhost:8080/jenkins/ to test your changes. Add a job that produces your bug / feature scenario.
