### PR TITLE
Require Jenkins 2.479.1 due to parent pom 5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <revision>3.4.1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/postbuildscript-plugin</gitHubRepo>
-    <jenkins.version>2.462.3</jenkins.version>
+    <jenkins.version>2.479.1</jenkins.version>
     <jenkins-test-harness.version>2228.v919b_5883c444</jenkins-test-harness.version>
     <hpi.compatibleSinceVersion>3.0.0</hpi.compatibleSinceVersion>
   </properties>


### PR DESCRIPTION
Since 9c448f0134, `mvn hpi:run` has failed due to some incompatibility with Jakarta. The commit bumped the parent pom to 5.0 which lists a breaking change:

> Since 5.0 the plugin parent pom now requires a minimum jenkins.version
> of 2.479 and to be run with Java 17
> * JENKINS-73339 - Require Java 17 and Jetty 12 (EE 9) for plugin
>   development (#1004)

The DependABot automatic update missed upgrading the Jenkins version.

Before submitting a pull request, please make sure the following is done:

Else I get:
```
$ mvn clean hpi:run
...
[WARNING] Failed startup of context oeje9mp.MavenWebAppContext@4f843511{
  Jenkins v2.462.3,
  /jenkins,
  file://<path to >/postbuildscript-plugin/target/jetty/webapp/,
  false
}{
  maven_repo/org/jenkins-ci/main/jenkins-war/2.462.3/jenkins-war-2.462.3.war
}
java.lang.IllegalStateException: class jenkins.security.SuspiciousRequestFilter is not a jakarta.servlet.Filter
    at org.eclipse.jetty.ee9.servlet.FilterHolder.doStart (FilterHolder.java:99)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:93)
    at org.eclipse.jetty.ee9.servlet.ServletHandler.lambda$initialize$2 (ServletHandler.java:726)
    at org.eclipse.jetty.util.ExceptionUtil.call (ExceptionUtil.java:333)
    at org.eclipse.jetty.util.ExceptionUtil$MultiException.callAndCatch (ExceptionUtil.java:270)
    at org.eclipse.jetty.ee9.servlet.ServletHandler.lambda$initialize$3 (ServletHandler.java:724)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining (ArrayList.java:1625)
    at java.util.stream.Streams$ConcatSpliterator.forEachRemaining (Streams.java:734)
    at java.util.stream.ReferencePipeline$Head.forEach (ReferencePipeline.java:762)
    at org.eclipse.jetty.ee9.servlet.ServletHandler.initialize (ServletHandler.java:752)
```

It works fine if bump the Jenkins version with the system property: `mvn -Djenkins.version=2.479.1 clean hpi:run`.