### PR TITLE
Adjust tests for script security

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutorFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/postbuildscript/service/GroovyScriptExecutorFactoryTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Descriptor.FormException;
 import java.util.Collections;
 import org.jenkinsci.plugins.postbuildscript.logging.Logger;
 import org.jenkinsci.plugins.postbuildscript.model.Script;
@@ -31,7 +32,7 @@ public class GroovyScriptExecutorFactoryTest {
     private GroovyScriptExecutorFactory executorFactory;
 
     @Test
-    public void createsExecutor() {
+    public void createsExecutor() throws FormException {
 
         given(script.getContent()).willReturn("scriptContent");
         given(script.isSandboxed()).willReturn(true);


### PR DESCRIPTION
In #229, I have adjust the source code to take in account the scripty security plugin can now throw a FormException. I only checked it with `mvn compile` and missed that tests were not compiled and had to be adjusted.

Tested locally with `mvn verify`

