### PR TITLE
Stop pinning jenkins-test-harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/postbuildscript-plugin</gitHubRepo>
     <jenkins.version>2.479.1</jenkins.version>
-    <jenkins-test-harness.version>2228.v919b_5883c444</jenkins-test-harness.version>
     <hpi.compatibleSinceVersion>3.0.0</hpi.compatibleSinceVersion>
   </properties>
 


### PR DESCRIPTION
When upgrading the Jenkins version to 2.462.3 with f6d65b2fa38, the jenkins-test-harness version has been set to 2228.v919b_5883c444.

It is not compatible with Jenkins 2.479.1 (added by 9223a1ccbbb) and cause the InjectedTest test to fail. See:
https://github.com/jenkinsci/jenkins-test-harness/issues/830.

Remove jenkins-test-harness version pinning, this update it to 2341.v35346d95d2b_7.

Before submitting a pull request, please make sure the following is done:

1. Fork [the repository](https://github.com/jenkinsci/postbuildscript-plugin) and create your branch from `master`.
2. If you've fixed a bug or added code that should be tested, please add JUnit tests.
3. Ensure the test suite passes (`mvn clean verify`).
4. Run `mvn hpi:run` and go to http://localhost:8080/jenkins/ to test your changes. Add a job that produces your bug / feature scenario.
