### PR TITLE
Replace Apache Commons Lang 2 with Java APIs due to removal from core and security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,16 +103,17 @@
     <revision>3.4.1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/postbuildscript-plugin</gitHubRepo>
-    <jenkins.version>2.479.1</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi.compatibleSinceVersion>3.0.0</hpi.compatibleSinceVersion>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.462.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/postbuildscript/service/Command.java
+++ b/src/main/java/org/jenkinsci/plugins/postbuildscript/service/Command.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+
 
 public class Command {
 
@@ -21,7 +21,7 @@ public class Command {
     }
 
     private static Deque<String> parseLine(String command) {
-        if (StringUtils.isBlank(command)) {
+        if (command == null || command.isBlank()) {
             return new ArrayDeque<>(0);
         }
         command = command.trim();


### PR DESCRIPTION
This is a transitive dependency consumed from core that will be removed. See

Can be replaced with native Java API instead of commons lang3

Before submitting a pull request, please make sure the following is done:

1. Fork [the repository](https://github.com/jenkinsci/postbuildscript-plugin) and create your branch from `master`.
2. If you've fixed a bug or added code that should be tested, please add JUnit tests.
3. Ensure the test suite passes (`mvn clean verify`).
4. Run `mvn hpi:run` and go to http://localhost:8080/jenkins/ to test your changes. Add a job that produces your bug / feature scenario.
